### PR TITLE
🌐 fix(locale): improve Turkish (tr-TR) translations

### DIFF
--- a/locales/tr-TR/chat.json
+++ b/locales/tr-TR/chat.json
@@ -32,7 +32,7 @@
   "duplicateTitle": "{{title}} Kopya",
   "emptyAgent": "Asistan yok",
   "historyRange": "Geçmiş Aralığı",
-  "historySummary": "Tarihsel haber özeti",
+  "historySummary": "Geçmiş mesaj özeti",
   "inbox": {
     "desc": "Beyin fırtınasını başlatın ve yaratıcı düşünmeye başlayın. Sanal asistanınız burada, her konuda sizinle iletişim kurmak için hazır.",
     "title": "Sohbet Et"
@@ -72,7 +72,7 @@
   },
   "newAgent": "Yeni Asistan",
   "pin": "Pin",
-  "pinOff": "Unpin",
+  "pinOff": "Sabitlemeyi Kaldır",
   "rag": {
     "referenceChunks": "Referans Parçaları",
     "userQuery": {
@@ -155,8 +155,8 @@
     "clear": "Çeviriyi Temizle"
   },
   "tts": {
-    "action": "Text-to-Speech",
-    "clear": "Clear Speech"
+    "action": "Metni Seslendir",
+    "clear": "Seslendirmeyi Temizle"
   },
   "updateAgent": "Asistan Bilgilerini Güncelle",
   "upload": {

--- a/locales/tr-TR/common.json
+++ b/locales/tr-TR/common.json
@@ -25,7 +25,7 @@
     "showDetail": "Detayları Görüntüle"
   },
   "autoGenerate": "Otomatik Oluştur",
-  "autoGenerateTooltip": "Auto-generate agent description based on prompts",
+  "autoGenerateTooltip": "İstemlere dayalı olarak asistan açıklamasını otomatik oluştur",
   "autoGenerateTooltipDisabled": "Otomatik tamamlama işlevini kullanmadan önce ipucu kelimesini girin",
   "back": "Geri",
   "batchDelete": "Toplu Sil",
@@ -33,7 +33,7 @@
   "branching": "Alt konu oluştur",
   "branchingDisable": "«Alt konu» özelliği yalnızca sunucu sürümünde mevcuttur. Bu özelliği kullanmak için lütfen sunucu dağıtım moduna geçin veya LobeChat Cloud'u kullanın.",
   "cancel": "İptal",
-  "changelog": "Changelog",
+  "changelog": "Değişiklik Günlüğü",
   "clientDB": {
     "autoInit": {
       "title": "PGlite veritabanı başlatılıyor"
@@ -109,7 +109,7 @@
     "allAgentWithMessage": "Tüm Asistan ve Mesajları Dışa Aktar",
     "globalSetting": "Ayarları Dışa Aktar"
   },
-  "feedback": "Feedback",
+  "feedback": "Geri Bildirim",
   "follow": "Bizi {{name}} üzerinde takip edin",
   "footer": {
     "action": {
@@ -213,14 +213,14 @@
   "oauth": "SSO Girişi",
   "officialSite": "Resmi Site",
   "ok": "Tamam",
-  "password": "Password",
+  "password": "Şifre",
   "pin": "Pin",
-  "pinOff": "Unpin",
+  "pinOff": "Sabitlemeyi Kaldır",
   "privacy": "Gizlilik Politikası",
   "regenerate": "Tekrarla",
   "releaseNotes": "Sürüm Detayları",
   "rename": "Yeniden İsimlendir",
-  "reset": "Reset",
+  "reset": "Sıfırla",
   "retry": "Yeniden Dene",
   "send": "Gönder",
   "setting": "Ayarlar",
@@ -260,7 +260,7 @@
     }
   },
   "tab": {
-    "chat": "Chat",
+    "chat": "Sohbet",
     "discover": "Keşfet",
     "files": "Dosyalar",
     "me": "ben",

--- a/locales/tr-TR/error.json
+++ b/locales/tr-TR/error.json
@@ -68,7 +68,7 @@
     "510": "Üzgünüm, sunucu isteğinizi genişletme işlevini desteklemiyor, lütfen yöneticinizle iletişime geçin",
     "524": "Üzgünüm, sunucu yanıt beklerken zaman aşımına uğradı, bu muhtemelen yanıtın çok yavaş olmasından kaynaklanıyor, lütfen daha sonra tekrar deneyin",
     "AgentRuntimeError": "Lobe dil modeli çalışma zamanı hatası, lütfen aşağıdaki bilgilere göre sorunu gidermeye çalışın veya tekrar deneyin",
-    "ConnectionCheckFailed": "İstek boş döndü, lütfen API代理地址ının sonuna `/v1` ekleyip eklemediğinizi kontrol edin.",
+    "ConnectionCheckFailed": "İstek boş döndü, lütfen API proxy adresinin sonuna `/v1` ekleyip eklemediğinizi kontrol edin.",
     "FreePlanLimit": "Şu anda ücretsiz bir kullanıcısınız, bu özelliği kullanamazsınız. Lütfen devam etmek için bir ücretli plana yükseltin.",
     "InvalidAccessCode": "Geçersiz Erişim Kodu: Geçersiz veya boş bir şifre girdiniz. Lütfen doğru erişim şifresini girin veya özel API Anahtarı ekleyin.",
     "InvalidBedrockCredentials": "Bedrock kimlik doğrulaması geçersiz, lütfen AccessKeyId/SecretAccessKey bilgilerinizi kontrol edip tekrar deneyin",

--- a/locales/tr-TR/file.json
+++ b/locales/tr-TR/file.json
@@ -6,7 +6,7 @@
       "filename": "Dosya Adı",
       "size": "Dosya Boyutu",
       "title": "Temel Bilgiler",
-      "type": "Format",
+      "type": "Dosya Türü",
       "updatedAt": "Güncellenme Zamanı"
     },
     "data": {

--- a/locales/tr-TR/market.json
+++ b/locales/tr-TR/market.json
@@ -6,13 +6,13 @@
     "func1": {
       "desc1": "Sohbet penceresinin sağ üst köşesindeki ayarlar simgesine tıklayarak asistana göndermek istediğiniz ayarlar sayfasına girin.",
       "desc2": "Sağ üst köşedeki 'Asistan Pazarına Gönder' düğmesine tıklayın.",
-      "tag": "Method 1",
+      "tag": "Yöntem 1",
       "title": "LobeChat üzerinden Gönder"
     },
     "func2": {
       "button": "Github Asistan Repositorisine Git",
       "desc": "Asistanı dizine eklemek istiyorsanız, plugins dizininde agent-template.json veya agent-template-full.json kullanarak bir giriş oluşturun, kısa bir açıklama ve uygun etiketler yazın, ardından bir çekme isteği oluşturun.",
-      "tag": "Method 2",
+      "tag": "Yöntem 2",
       "title": "Github üzerinden Gönder"
     }
   },
@@ -21,7 +21,7 @@
   },
   "sidebar": {
     "comment": "Yorumlar",
-    "prompt": "Prompts",
+    "prompt": "İstemler",
     "title": "Asistan Detay"
   },
   "submitAgent": "Asistan Ekle",

--- a/locales/tr-TR/modelProvider.json
+++ b/locales/tr-TR/modelProvider.json
@@ -88,10 +88,10 @@
       "title": "Özel Model Adları"
     },
     "download": {
-      "desc": "Ollama 正在下载该模型，请尽量不要关闭本页面。重新下载时将会中断处继续",
-      "remainingTime": "剩余时间",
-      "speed": "下载速度",
-      "title": "正在下载模型 {{model}} "
+      "desc": "Ollama bu modeli indiriyor, lütfen bu sayfayı kapatmamaya çalışın. Yeniden indirme kaldığı yerden devam edecektir.",
+      "remainingTime": "Kalan süre",
+      "speed": "İndirme hızı",
+      "title": "{{model}} modeli indiriliyor"
     },
     "endpoint": {
       "desc": "Ollama arayüz proxy adresini girin, yerel olarak belirtilmemişse boş bırakılabilir",
@@ -123,12 +123,12 @@
     },
     "title": "Ollama",
     "unlock": {
-      "cancel": "取消下载",
-      "confirm": "下载",
-      "description": "输入你的 Ollama 模型标签，完成即可继续会话",
+      "cancel": "İndirmeyi iptal et",
+      "confirm": "İndir",
+      "description": "Ollama model etiketinizi girin, tamamlandığında konuşmaya devam edebilirsiniz",
       "downloaded": "{{completed}} / {{total}}",
-      "starting": "开始下载...",
-      "title": "下载指定的 Ollama 模型"
+      "starting": "İndirme başlıyor...",
+      "title": "Belirtilen Ollama modelini indir"
     }
   },
   "sensenova": {

--- a/locales/tr-TR/setting.json
+++ b/locales/tr-TR/setting.json
@@ -133,7 +133,7 @@
   },
   "settingAgent": {
     "avatar": {
-      "title": "Avatar"
+      "title": "Profil Resmi"
     },
     "backgroundColor": {
       "title": "Arka Plan Rengi"
@@ -203,15 +203,15 @@
     },
     "frequencyPenalty": {
       "desc": "Değer ne kadar yüksekse, tekrarlayan kelimeleri azaltma olasılığı o kadar yüksektir",
-      "title": "Frequency Penalty"
+      "title": "Tekrar Cezası"
     },
     "maxTokens": {
       "desc": "Her etkileşim için kullanılan maksimum token sayısı",
       "title": "Max Token Sınırlaması"
     },
     "model": {
-      "desc": "{{provider}} Model",
-      "title": "Model"
+      "desc": "{{provider}} Modeli",
+      "title": "Model Seçimi"
     },
     "presencePenalty": {
       "desc": "Değer ne kadar yüksekse, yeni konulara genişleme olasılığı o kadar yüksektir",
@@ -219,7 +219,7 @@
     },
     "temperature": {
       "desc": "Değer ne kadar yüksekse, yanıt o kadar rastgele olur",
-      "title": "Randomness",
+      "title": "Rastgelelik",
       "titleWithValue": "temperature {{value}}"
     },
     "title": "Model Ayarları",
@@ -258,7 +258,7 @@
   "settingTTS": {
     "openai": {
       "sttModel": "OpenAI Konuşmadan Metne Modeli",
-      "title": "OpenAI",
+      "title": "OpenAI Ses Servisi",
       "ttsModel": "OpenAI Metin Seslendirme Modeli"
     },
     "showAllLocaleVoice": {
@@ -292,12 +292,12 @@
   },
   "settingTheme": {
     "avatar": {
-      "title": "Avatar"
+      "title": "Profil Resmi"
     },
     "fontSize": {
       "desc": "Sohbet içeriği için yazı boyutu",
       "marks": {
-        "normal": "Normal"
+        "normal": "Orta"
       },
       "title": "Yazı Boyutu"
     },


### PR DESCRIPTION
## Summary

Fix Turkish (tr-TR) locale files containing Chinese (zh-CN) text remnants, untranslated English strings, and incorrect translations across 7 locale files.

### Problem

- **Chinese text in Turkish locale**: \modelProvider.json\ contained 9 Chinese strings in the Ollama download/unlock sections that were never translated
- **Mixed Chinese characters**: \error.json\ had Chinese characters (\API代理地址\) embedded within a Turkish sentence
- **Untranslated English strings**: Multiple files had English text left untranslated (\Password\, \Reset\, \Changelog\, \Feedback\, \Chat\, \Unpin\, \Clear Speech\, \Text-to-Speech\, etc.)
- **Incorrect translation**: \historySummary\ was translated as \Tarihsel haber özeti\ (historical news summary) instead of \Geçmiş mesaj özeti\ (history message summary)

## Changes

- [x] **\locales/tr-TR/modelProvider.json\** — Translated 9 Chinese strings in Ollama download/unlock sections to Turkish
- [x] **\locales/tr-TR/error.json\** — Fixed \ConnectionCheckFailed\ message containing Chinese characters
- [x] **\locales/tr-TR/chat.json\** — Translated \	ts.action\, \	ts.clear\, \pinOff\; fixed \historySummary\ mistranslation
- [x] **\locales/tr-TR/common.json\** — Translated \utoGenerateTooltip\, \changelog\, \eedback\, \password\, \pinOff\, \eset\, \	ab.chat\
- [x] **\locales/tr-TR/setting.json\** — Translated \settingAgent.avatar\, \settingModel.frequencyPenalty\, \settingModel.model\, \settingModel.temperature\, \settingTTS.openai.title\, \settingTheme.avatar\, \settingTheme.fontSize.marks.normal\
- [x] **\locales/tr-TR/market.json\** — Translated \guide.func1.tag\, \guide.func2.tag\, \sidebar.prompt\
- [x] **\locales/tr-TR/file.json\** — Translated \detail.basic.type\

### Files affected: 7 | Total lines changed: 33

> **Note**: Brand names and technical identifiers (e.g. \Azure OpenAI\, \Bedrock\, \Ollama\, \API Key\, \AWS Access Key Id\) are intentionally kept in English, consistent with other locale files (ja-JP, de-DE, etc.).